### PR TITLE
Pipeline scripts Steps 1 & 2

### DIFF
--- a/inst/scripts/WriteSeuratMetadata.R
+++ b/inst/scripts/WriteSeuratMetadata.R
@@ -1,0 +1,27 @@
+library(Seurat)
+library(data.table)
+
+files <- list.files(".",full.names = TRUE )
+
+# identify the Seurat object
+if(length(grep("seuratObject", files)) == 1) {
+  seuratObj <- readRDS(files[grepl("seuratObject", files)])
+} else if ( length(grep("Seurat", files)) > 1) {
+  stop("Multiple Seurat objects found. Please remove the extra Seurat objects.")
+} else {
+  stop("No Seurat object found in the specified directory.")
+}
+
+#identify Seurat metadata containing the celltyping from InSituType
+#the column names containing the cell type annotations start with RNA_nbclust and end with _1_clusters, but contain a random hash 
+cell_type_columns <- colnames(seuratObj@meta.data)[grepl("RNA_nbclust", colnames(seuratObj@meta.data)) & 
+                                                     !grepl("posterior_probability", colnames(seuratObj@meta.data))]
+if (length(cell_type_columns) == 0) {
+  stop("No cell type columns found in the metadata.")
+}
+#extract the relevant metadata
+cell_metadata <- seuratObj@meta.data[, c("cell_ID", cell_type_columns), drop = FALSE] 
+colnames(cell_metadata) <-c("cell_ID", paste0("cell_type_", 1:length(cell_type_columns)))
+
+#write metadata to a file named _metadata.csv to be loaded in napari. 
+data.table::fwrite(cell_metadata, "/work/StitchedImage/_metadata.csv")

--- a/inst/submitScripts/DownloadFromAtoMx.sh
+++ b/inst/submitScripts/DownloadFromAtoMx.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# usage: DownloadFromAtoMx.sh [subdirectory]
+# The subdirectory is the name of the subdirectory in the AtoMx SFTP server where the data is stored.
+# If no subdirectory is provided, the script will download all directories currently on the AtoMx SFTP server, but will prompt the user. 
+# In reality, there's probably not much there, but could be quite large amounts of data. 
+
+set -e
+
+SCRIPT=${1}.exp
+wget -O $SCRIPT https://raw.githubusercontent.com/EstesLab/CosMxUtils/refs/heads/main/inst/scripts/sftp_get_all.exp
+chmod +x $SCRIPT
+
+if [[ -z $1 ]];then
+        echo "No subdirectory provided. By default, ALL files Stephen has exported will be downloaded. Is that desired?\nEnter 'yes' below, or 'no' to cancel."
+        read -p "Response:" response
+        if [[ $response = 'yes' ]];then
+                echo "Creating downloads directory to store downloads."
+                mkdir downloads
+                cd downloads
+                sbatch \
+                        --job-name="AtoMxDownloadAll" \
+                        --mem 8000 \
+                        --cpus-per-task=2 \
+                        --output=downloadAll.log \
+                        --error=downloadAll.error \
+                        --partition=batch \
+                        --time=0-36 \
+                        --chdir=$PWD \
+                        ../$SCRIPT
+        elif [[ $response = 'no' ]];then
+                echo "Set the subdirectory by executing this script again with the desired subdirectory as the first and only argument."
+                exit 1
+        else
+                exit 1
+        fi
+else
+        mkdir $1
+        cd $1
+        sbatch \
+                        --job-name=$1 \
+                        --mem 8000 \
+                        --cpus-per-task=2 \
+                        --output=$1.log \
+                        --error=$1.error \
+                        --partition=batch \
+                        --time=0-36 \
+                        --chdir=$PWD \
+                        ../$SCRIPT $1
+fi

--- a/inst/submitScripts/StitchAtoMxDirectories.sh
+++ b/inst/submitScripts/StitchAtoMxDirectories.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#usage: StitchAtoMxDirectories.sh
+# This script will loop over all directories in the current working directory and 
+# stitch the images in the CellStatsDir and RunSummary directories to be ingested by napari. 
+# This script also writes a _metadata.csv file to each Stitched image directory, 
+# which containing unsupervised clustering results.
+set -e
+
+PWD=$(pwd)
+
+#pull the CosMxUtils image
+srun apptainer --disable-cache pull NapariStitch.sif docker://ghcr.io/esteslab/naparistitch:nightly
+NAPARISIF=${PWD}/NapariStitch.sif
+
+#loop over directories 
+subdirectories=$(ls -d $PWD/*/)
+for dir in  ${subdirectories}
+do
+    #set up the directory variables
+    dir=${dir%*/}
+    WD=$dir
+    HOME=`echo ~/`
+    CELLSTATSDIR=$(find $dir -type d -name CellStatsDir)
+    RUNSUMMARYDIR=$(find $dir -type d -name RunSummary)
+    ANALYSISRESULTSDIR=$(find $dir -type d -name AnalysisResults)
+    #make the output directory
+    mkdir -p ${WD}/StitchedImage
+    #get the script that writes the unsupervised clustering results.
+    wget -O WriteSeuratMetadata.R https://raw.githubusercontent.com/EstesLab/CosMxUtils/refs/heads/main/inst/scripts/WriteSeuratMetadata.R
+    #submit a stitching job and write a _metadata.csv file to each Stitched image directory containing unsupervised clustering results.
+    sbatch \
+         --job-name=StitchImages \
+         --mem 8000 \
+         --cpus-per-task=2 \
+         --output=${dir}/stitching.log \
+         --error=${dir}/stitching.error \
+         --partition=batch \
+         --time=0-36 \
+         --chdir=$dir \
+         apptainer exec \
+            -B "${WD}:/work" \
+            -B "${HOME}:/homeDir" \
+            $NAPARISIF \
+              /bin/bash -c \
+                "stitch-images -i $CELLSTATSDIR -f $RUNSUMMARYDIR -o StitchedImage;
+                read-targets $ANALYSISRESULTSDIR -o StitchedImage;
+                Rscript --vanilla /work/WriteSeuratMetadata.R"
+          #TODO: delete the original ATOMX exports. 
+done
+
+#clean cache
+yes | apptainer cache clean
+
+


### PR DESCRIPTION
Hi everyone, 

I'm adding the first two steps of the "Data Ingestion" pipeline to the repo. The scripts in /inst/submitScripts pull down scripts from the inst/scripts directory and kick off slurm jobs to perform the desired steps. A user will have to satisfy some details that I am keeping internal before these steps can be run, but I'm happy to discuss over email. 

Best regards, 
GW